### PR TITLE
POC: speed up remote builds by caching `GetActionResult` and `FindMissingBlobs`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/bazelbuild/remote-apis v0.0.0-20230822133051-6c32c3b917cc
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	google.golang.org/genproto v0.0.0-20231106174013-bbf56f31fb17
 	google.golang.org/genproto/googleapis/bytestream v0.0.0-20231016165738-49dd2c1f3d0b
 	google.golang.org/grpc v1.59.0

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/main.go
+++ b/main.go
@@ -39,7 +39,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	// TODO: if possible, it would be smarter to re-use the TLS config from the client rather than setting it up again here
 	tlsConf := &tls.Config{}
 	readCert, err := tls.LoadX509KeyPair(clientCertFile, clientCertKeyFile)
 	if err != nil {


### PR DESCRIPTION
before:

```
INFO: Elapsed time: 94.825s, Critical Path: 51.39s
INFO: 11014 processes: 5504 remote cache hit, 5510 internal.
INFO: Build completed successfully, 11014 total actions
```

after:

```
INFO: Elapsed time: 67.897s, Critical Path: 26.42s
INFO: 11014 processes: 5504 remote cache hit, 5510 internal.
INFO: Build completed successfully, 11014 total actions
```